### PR TITLE
implement geolocation interface from profile settings - address book 

### DIFF
--- a/components/AccordionFormList/AccordionFormList.js
+++ b/components/AccordionFormList/AccordionFormList.js
@@ -238,6 +238,7 @@ class AccordionFormList extends Component {
 						<ItemEditForm
 							{...itemEditFormProps}
 							ref={(el) => {
+								console.log(el);
 								this._refs[`editForm_${id}`] = el;
 							}}
 						/>

--- a/components/AccordionFormList/AccordionFormList.js
+++ b/components/AccordionFormList/AccordionFormList.js
@@ -2,8 +2,6 @@ import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { applyTheme, addTypographyStyles, CustomPropTypes } from "@reactioncommerce/components/utils";
-import GoogleMapComponent from "components/GoogleMaps";
-import { SearchBox } from "react-google-maps/lib/components/places/SearchBox";
 import inject from "hocs/inject";
 import { withComponents } from "@reactioncommerce/components-context";
 
@@ -76,21 +74,6 @@ const FormActionDelete = styled.div`
 
 const ENTRY = "entry";
 const LIST = "list";
-
-const PlacesWithSearchBox = (props) => {
-	return <SearchBox
-		ref={props.onSearchBoxMounted}
-		bounds={props.bounds}
-		onPlacesChanged={() => {
-			props.onPlacesChanged(props.authStore.accessToken);
-		}}
-		controlPosition={google.maps.ControlPosition.TOP_LEFT}
-	>
-		<div style={{ width: "50%", padding: "10px" }}>
-			{props.children}
-		</div>
-	</SearchBox>;
-};
 
 class AccordionFormList extends Component {
 	static propTypes = {
@@ -258,27 +241,6 @@ class AccordionFormList extends Component {
 								this._refs[`editForm_${id}`] = el;
 							}}
 						/>
-						<div
-							style={{
-								width: "100%",
-								height: "300px"
-							}}
-						>
-							<GoogleMapComponent {...googleProps}
-								authStore={this.props.authStore}
-								SearchBox={
-									<PlacesWithSearchBox
-										{...this.props}
-										{...googleProps}>
-										<TextInput
-											id="search"
-											name="search"
-											placeholder="buscar una dirección"
-										/>
-									</PlacesWithSearchBox>
-								}
-							/>
-						</div>
 						<FormActions>
 							<FormActionDelete>
 								<Button
@@ -327,27 +289,6 @@ class AccordionFormList extends Component {
 						this._addItemForm = el;
 					}}
 				/>
-				<div
-					style={{
-						width: "100%",
-						height: "300px"
-					}}
-				>
-					<GoogleMapComponent {...googleProps}
-						authStore={this.props.authStore}
-						SearchBox={
-							<PlacesWithSearchBox
-								{...this.props}
-								{...googleProps}>
-								<TextInput
-									id="search"
-									name="search"
-									placeholder="buscar una dirección"
-								/>
-							</PlacesWithSearchBox>
-						}
-					/>
-				</div>
 				<FormActions>
 					<Button actionType="secondary" onClick={this.handleEntryFormCancel}>
 						{cancelButtonText}

--- a/components/AccordionFormList/AccordionFormList.js
+++ b/components/AccordionFormList/AccordionFormList.js
@@ -224,6 +224,7 @@ class AccordionFormList extends Component {
 			saveButtonText,
 			googleProps
 		} = this.props;
+		
 		return (
 			<Fragment>
 				{items && items.map(({ detail, id, itemEditFormProps, label }) => (
@@ -237,8 +238,7 @@ class AccordionFormList extends Component {
 					>
 						<ItemEditForm
 							{...itemEditFormProps}
-							ref={(el) => {
-								console.log(el);
+							formRef = {(el) => {
 								this._refs[`editForm_${id}`] = el;
 							}}
 						/>
@@ -286,7 +286,7 @@ class AccordionFormList extends Component {
 			<Fragment>
 				<ItemAddForm
 					{...itemAddFormProps}
-					ref={(el) => {
+					formRef={(el) => {
 						this._addItemForm = el;
 					}}
 				/>

--- a/components/AccordionFormList/AccordionFormList.js
+++ b/components/AccordionFormList/AccordionFormList.js
@@ -1,8 +1,11 @@
 import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { withComponents } from "@reactioncommerce/components-context";
 import { applyTheme, addTypographyStyles, CustomPropTypes } from "@reactioncommerce/components/utils";
+import GoogleMapComponent from "components/GoogleMaps";
+import { SearchBox } from "react-google-maps/lib/components/places/SearchBox";
+import inject from "hocs/inject";
+import { withComponents } from "@reactioncommerce/components-context";
 
 const AddNewItemAction = styled.div`
   border-color: ${applyTheme("Accordion.borderColor")};
@@ -74,240 +77,298 @@ const FormActionDelete = styled.div`
 const ENTRY = "entry";
 const LIST = "list";
 
+const PlacesWithSearchBox = (props) => {
+	return <SearchBox
+		ref={props.onSearchBoxMounted}
+		bounds={props.bounds}
+		onPlacesChanged={() => {
+			props.onPlacesChanged(props.authStore.accessToken);
+		}}
+		controlPosition={google.maps.ControlPosition.TOP_LEFT}
+	>
+		<div style={{ width: "50%", padding: "10px" }}>
+			{props.children}
+		</div>
+	</SearchBox>;
+};
+
 class AccordionFormList extends Component {
-  static propTypes = {
-  	/**
-     * Text to show on the button for adding a new item to the list
-     */
-  	addNewItemButtonText: PropTypes.string,
-  	/**
-     * The text for the "Cancel" text, if it is shown.
-     */
-  	cancelButtonText: PropTypes.string,
-  	/**
-     * You can provide a `className` prop that will be applied to the outermost DOM element
-     * rendered by this component. We do not recommend using this for styling purposes, but
-     * it can be useful as a selector in some situations.
-     */
-  	className: PropTypes.string,
-  	/**
-     * If you've set up a components context using @reactioncommerce/components-context
-     * (recommended), then this prop will come from there automatically. If you have not
-     * set up a components context or you want to override one of the components in a
-     * single spot, you can pass in the components prop directly.
-     */
-  	components: PropTypes.shape({
-  		/**
-       * Pass either the Reaction Accordion component or your own component that
-       * accepts compatible props.
-       */
-  		Accordion: CustomPropTypes.component.isRequired,
-  		/**
-       * Pass either the Reaction iconPlus component or your own component that
-       * accepts compatible props.
-       */
-  		iconPlus: PropTypes.node.isRequired,
-  		/**
-       * The form component to render when adding a new item. It must have a
-       * "submit" method on the instance or forward "ref" to a component that does.
-       */
-  		ItemAddForm: CustomPropTypes.component.isRequired,
-  		/**
-       * The form component to render when editing an item. It must have a
-       * "submit" method on the instance or forward "ref" to a component that does.
-       */
-  		ItemEditForm: CustomPropTypes.component.isRequired
-  	}).isRequired,
-  	/**
-     * Text to show on the button for deleting an item from the list
-     */
-  	deleteItemButtonText: PropTypes.string,
-  	/**
-     * Text to show on the button for submitting the new item entry form
-     */
-  	entryFormSubmitButtonText: PropTypes.string,
-  	/**
-     * Is some async operation happening? Puts buttons into waiting state
-     */
-  	isWaiting: PropTypes.bool,
-  	/**
-     * Arbitrary props to pass to ItemAddForm instance
-     */
-  	itemAddFormProps: PropTypes.object,
-  	/**
-     * The list of items to show accordion edit forms for
-     */
-  	items: PropTypes.arrayOf(PropTypes.shape({
-  		/**
-       * Accordion detail
-       */
-  		detail: PropTypes.string,
-  		/**
-       * A unique ID
-       */
-  		id: PropTypes.string.isRequired,
-  		/**
-       * Arbitrary props to pass to ItemEditForm instance
-       */
-  		itemEditFormProps: PropTypes.object,
-  		/**
-       * Accordion label
-       */
-  		label: PropTypes.string.isRequired
-  	})),
-  	/**
-     * Handles item deletion from list
-     */
-  	onItemDeleted: PropTypes.func,
-  	/**
-     * The text for the "Save" text, if it is shown.
-     */
-  	saveButtonText: PropTypes.string
-  };
+	static propTypes = {
+		/**
+	 * Text to show on the button for adding a new item to the list
+	 */
+		addNewItemButtonText: PropTypes.string,
+		/**
+	 * The text for the "Cancel" text, if it is shown.
+	 */
+		cancelButtonText: PropTypes.string,
+		/**
+	 * You can provide a `className` prop that will be applied to the outermost DOM element
+	 * rendered by this component. We do not recommend using this for styling purposes, but
+	 * it can be useful as a selector in some situations.
+	 */
+		className: PropTypes.string,
+		/**
+	 * If you've set up a components context using @reactioncommerce/components-context
+	 * (recommended), then this prop will come from there automatically. If you have not
+	 * set up a components context or you want to override one of the components in a
+	 * single spot, you can pass in the components prop directly.
+	 */
+		components: PropTypes.shape({
+			/**
+	   * Pass either the Reaction Accordion component or your own component that
+	   * accepts compatible props.
+	   */
+			Accordion: CustomPropTypes.component.isRequired,
+			/**
+	   * Pass either the Reaction iconPlus component or your own component that
+	   * accepts compatible props.
+	   */
+			iconPlus: PropTypes.node.isRequired,
+			/**
+	   * The form component to render when adding a new item. It must have a
+	   * "submit" method on the instance or forward "ref" to a component that does.
+	   */
+			ItemAddForm: CustomPropTypes.component.isRequired,
+			/**
+	   * The form component to render when editing an item. It must have a
+	   * "submit" method on the instance or forward "ref" to a component that does.
+	   */
+			ItemEditForm: CustomPropTypes.component.isRequired
+		}).isRequired,
+		/**
+	 * Text to show on the button for deleting an item from the list
+	 */
+		deleteItemButtonText: PropTypes.string,
+		/**
+	 * Text to show on the button for submitting the new item entry form
+	 */
+		entryFormSubmitButtonText: PropTypes.string,
+		/**
+	 * Is some async operation happening? Puts buttons into waiting state
+	 */
+		isWaiting: PropTypes.bool,
+		/**
+	 * Arbitrary props to pass to ItemAddForm instance
+	 */
+		itemAddFormProps: PropTypes.object,
+		/**
+	 * The list of items to show accordion edit forms for
+	 */
+		items: PropTypes.arrayOf(PropTypes.shape({
+			/**
+	   * Accordion detail
+	   */
+			detail: PropTypes.string,
+			/**
+	   * A unique ID
+	   */
+			id: PropTypes.string.isRequired,
+			/**
+	   * Arbitrary props to pass to ItemEditForm instance
+	   */
+			itemEditFormProps: PropTypes.object,
+			/**
+	   * Accordion label
+	   */
+			label: PropTypes.string.isRequired
+		})),
+		/**
+	 * Handles item deletion from list
+	 */
+		onItemDeleted: PropTypes.func,
+		/**
+	 * The text for the "Save" text, if it is shown.
+	 */
+		saveButtonText: PropTypes.string
+	};
 
-  static defaultProps = {
-  	addNewItemButtonText: "Agregar un item",
-  	deleteItemButtonText: "Borrar este item",
-  	entryFormSubmitButtonText: "Agregar item",
-  	cancelButtonText: "Cancelar",
-  	saveButtonText: "Guardar cambios",
-  	isWaiting: false,
-  	onItemDeleted() {}
-  };
+	static defaultProps = {
+		addNewItemButtonText: "Agregar un item",
+		deleteItemButtonText: "Borrar este item",
+		entryFormSubmitButtonText: "Agregar item",
+		cancelButtonText: "Cancelar",
+		saveButtonText: "Guardar cambios",
+		isWaiting: false,
+		onItemDeleted() { }
+	};
 
-  state = {
-  	status: LIST
-  };
+	state = {
+		status: LIST
+	};
 
-  _refs = {};
+	_refs = {};
 
-  //
-  // Handler Methods
-  //
-  handleDeleteItem = (itemId) => {
-  	const { onItemDeleted } = this.props;
-  	onItemDeleted(itemId);
-  };
+	//
+	// Handler Methods
+	//
+	handleDeleteItem = (itemId) => {
+		const { onItemDeleted } = this.props;
+		onItemDeleted(itemId);
+	};
 
-  handleAddClick = () => {
-  	this.showEntryForm();
-  };
+	handleAddClick = () => {
+		this.showEntryForm();
+	};
 
-  handleEntryFormCancel = () => {
-  	this.showList();
-  };
+	handleEntryFormCancel = () => {
+		this.showList();
+	};
 
-  showEntryForm() {
-  	this.setState({ status: ENTRY });
-  }
+	showEntryForm() {
+		this.setState({ status: ENTRY });
+	}
 
-  showList() {
-  	this.setState({ status: LIST });
-  }
+	showList() {
+		this.setState({ status: LIST });
+	}
 
-  toggleAccordionForItem(itemId) {
-  	this._refs[`accordion_${itemId}`].toggle();
-  }
+	toggleAccordionForItem(itemId) {
+		this._refs[`accordion_${itemId}`].toggle();
+	}
 
-  //
-  // Render Methods
-  //
-  renderAccordion() {
-  	const {
-  		addNewItemButtonText,
-  		cancelButtonText,
-  		components: { Accordion, Button, iconPlus, ItemEditForm },
-  		deleteItemButtonText,
-  		isWaiting,
-  		items,
-  		saveButtonText
-  	} = this.props;
-  	return (
-  		<Fragment>
-  			{items && items.map(({ detail, id, itemEditFormProps, label }) => (
-  				<Accordion
-  					key={id}
-  					label={label}
-  					detail={detail}
-  					ref={(el) => {
-  						this._refs[`accordion_${id}`] = el;
-  					}}
-  				>
-  					<ItemEditForm
-  						{...itemEditFormProps}
-  						ref={(el) => {
-  							this._refs[`editForm_${id}`] = el;
-  						}}
-  					/>
-  					<FormActions>
-  						<FormActionDelete>
-  							<Button
-  								actionType="secondaryDanger"
-  								isTextOnlyNoPadding
-  								isShortHeight
-  								onClick={() => {
-  									this.handleDeleteItem(id);
-  								}}
-  							>
-  								{deleteItemButtonText}
-  							</Button>
-  						</FormActionDelete>
-  						<Button
-  							actionType="secondary"
-  							isShortHeight
-  							onClick={() => {
-  								this.toggleAccordionForItem(id);
-  							}}
-  						>
-  							{cancelButtonText}
-  						</Button>
-  						<Button onClick={() => this._refs[`editForm_${id}`].submit()} isShortHeight isWaiting={isWaiting}>
-  							{saveButtonText}
-  						</Button>
-  					</FormActions>
-  				</Accordion>
-  			))}
-  			<AddNewItemAction listCount={items && items.length}>
-  				<AddNewItemActionButton onClick={this.handleAddClick} tabIndex={0}>
-  					<AddNewItemActionIcon>{iconPlus}</AddNewItemActionIcon>
-  					{addNewItemButtonText}
-  				</AddNewItemActionButton>
-  			</AddNewItemAction>
-  		</Fragment>
-  	);
-  }
+	//
+	// Render Methods
+	//
+	renderAccordion() {
+		const {
+			addNewItemButtonText,
+			cancelButtonText,
+			components: { Accordion, Button, iconPlus, ItemEditForm, TextInput },
+			deleteItemButtonText,
+			isWaiting,
+			items,
+			saveButtonText,
+			googleProps
+		} = this.props;
+		return (
+			<Fragment>
+				{items && items.map(({ detail, id, itemEditFormProps, label }) => (
+					<Accordion
+						key={id}
+						label={label}
+						detail={detail}
+						ref={(el) => {
+							this._refs[`accordion_${id}`] = el;
+						}}
+					>
+						<ItemEditForm
+							{...itemEditFormProps}
+							ref={(el) => {
+								this._refs[`editForm_${id}`] = el;
+							}}
+						/>
+						<div
+							style={{
+								width: "100%",
+								height: "300px"
+							}}
+						>
+							<GoogleMapComponent {...googleProps}
+								authStore={this.props.authStore}
+								SearchBox={
+									<PlacesWithSearchBox
+										{...this.props}
+										{...googleProps}>
+										<TextInput
+											id="search"
+											name="search"
+											placeholder="buscar una dirección"
+										/>
+									</PlacesWithSearchBox>
+								}
+							/>
+						</div>
+						<FormActions>
+							<FormActionDelete>
+								<Button
+									actionType="secondaryDanger"
+									isTextOnlyNoPadding
+									isShortHeight
+									onClick={() => {
+										this.handleDeleteItem(id);
+									}}
+								>
+									{deleteItemButtonText}
+								</Button>
+							</FormActionDelete>
+							<Button
+								actionType="secondary"
+								isShortHeight
+								onClick={() => {
+									this.toggleAccordionForItem(id);
+								}}
+							>
+								{cancelButtonText}
+							</Button>
+							<Button onClick={() => this._refs[`editForm_${id}`].submit()} isShortHeight isWaiting={isWaiting}>
+								{saveButtonText}
+							</Button>
+						</FormActions>
+					</Accordion>
+				))}
+				<AddNewItemAction listCount={items && items.length}>
+					<AddNewItemActionButton onClick={this.handleAddClick} tabIndex={0}>
+						<AddNewItemActionIcon>{iconPlus}</AddNewItemActionIcon>
+						{addNewItemButtonText}
+					</AddNewItemActionButton>
+				</AddNewItemAction>
+			</Fragment>
+		);
+	}
+ 
+	renderEntryForm() {
+		const { cancelButtonText, components: { Button, ItemAddForm, TextInput }, entryFormSubmitButtonText, isWaiting, itemAddFormProps, googleProps } = this.props;
+		return (
+			<Fragment>
+				<ItemAddForm
+					{...itemAddFormProps}
+					ref={(el) => {
+						this._addItemForm = el;
+					}}
+				/>
+				<div
+					style={{
+						width: "100%",
+						height: "300px"
+					}}
+				>
+					<GoogleMapComponent {...googleProps}
+						authStore={this.props.authStore}
+						SearchBox={
+							<PlacesWithSearchBox
+								{...this.props}
+								{...googleProps}>
+								<TextInput
+									id="search"
+									name="search"
+									placeholder="buscar una dirección"
+								/>
+							</PlacesWithSearchBox>
+						}
+					/>
+				</div>
+				<FormActions>
+					<Button actionType="secondary" onClick={this.handleEntryFormCancel}>
+						{cancelButtonText}
+					</Button>
+					<Button onClick={() => this._addItemForm.submit()} isWaiting={isWaiting}>
+						{entryFormSubmitButtonText}
+					</Button>
+				</FormActions>
+			</Fragment>
+		);
+	}
 
-  renderEntryForm() {
-  	const { cancelButtonText, components: { Button, ItemAddForm }, entryFormSubmitButtonText, isWaiting, itemAddFormProps } = this.props;
-  	return (
-  		<Fragment>
-  			<ItemAddForm
-  				{...itemAddFormProps}
-  				ref={(el) => {
-  					this._addItemForm = el;
-  				}}
-  			/>
-  			<FormActions>
-  				<Button actionType="secondary" onClick={this.handleEntryFormCancel}>
-  					{cancelButtonText}
-  				</Button>
-  				<Button onClick={() => this._addItemForm.submit()} isWaiting={isWaiting}>
-  					{entryFormSubmitButtonText}
-  				</Button>
-  			</FormActions>
-  		</Fragment>
-  	);
-  }
-
-  render() {
-  	const { className } = this.props;
-  	const { status } = this.state;
-  	return (
-  		<div className={className}>
-  			{status === LIST ? this.renderAccordion() : this.renderEntryForm()}
-  		</div>
-  	);
-  }
+	render() {
+		const { className } = this.props;
+		const { status } = this.state;
+		return (
+			<div className={className}>
+				{status === LIST ? this.renderAccordion() : this.renderEntryForm()}
+			</div>
+		);
+	}
 }
 
-export default withComponents(AccordionFormList);
+export default withComponents(inject("authStore")(AccordionFormList));

--- a/components/AddressBook/AddressBook.js
+++ b/components/AddressBook/AddressBook.js
@@ -27,13 +27,35 @@ const PlacesWithSearchBox = (props) => {
 };
 
 const CustomAddAddressForm = withGoogleMaps((props) => {
-	const { components: { CustomForm, TextInput }, googleProps, ...itemAddFormProps } = props;
+	// this.demo = "Hola mundo";
+	const { components: { CustomForm, TextInput }, onSubmit, googleProps, ...itemAddFormProps } = props;
+
+	const handleSubmit = (value) => {
+
+		const input = { ...value };
+		if (googleProps.locationRef.latitude) {
+			Object.assign(input, {
+				geolocation: googleProps.locationRef,
+				metaddress: { ...googleProps.metadataMarker }
+			});
+		}
+
+		onSubmit(input);
+	};
+
 	let _formRef = null;
+
+	function submit() {
+		console.log("submit function executed");
+		_formRef.submit();
+	}
 
 	return (
 		<div>
 			<CustomForm
 				{...itemAddFormProps}
+				onSubmit={handleSubmit}
+
 				ref={(formEl) => {
 					_formRef = formEl;
 				}}
@@ -62,41 +84,43 @@ const CustomAddAddressForm = withGoogleMaps((props) => {
 	);
 });
 
-const CustomEditAddressForm = withGoogleMaps((props) => {
-	const { components: { CustomForm, TextInput }, googleProps, ...itemAddFormProps } = props;
-	let _formRef = null;
+console.log(CustomAddAddressForm)
 
-	return (
-		<div>
-			<CustomForm
-				{...itemAddFormProps}
-				ref={(formEl) => {
-					_formRef = formEl;
-				}}
-			/>
-			<div style={{
-				width: "100%",
-				height: "300px"
-			}}>
-				<GoogleMapComponent
-					{...googleProps}
-					authStore={props.authStore}
-					SearchBox={
-						<PlacesWithSearchBox
-							{...props}
-							{...googleProps}>
-							<TextInput
-								id="search"
-								name="search"
-								placeholder="buscar una dirección"
-							/>
-						</PlacesWithSearchBox>
-					}
-				/>
-			</div>
-		</div>
-	);
-});
+// const CustomEditAddressForm = withGoogleMaps((props) => {
+// 	const { components: { CustomForm, TextInput }, googleProps, ...itemAddFormProps } = props;
+// 	let _formRef = null;
+
+// 	return (
+// 		<div>
+// 			<CustomForm
+// 				{...itemAddFormProps}
+// 				ref={(formEl) => {
+// 					_formRef = formEl;
+// 				}}
+// 			/>
+// 			<div style={{
+// 				width: "100%",
+// 				height: "300px"
+// 			}}>
+// 				<GoogleMapComponent
+// 					{...googleProps}
+// 					authStore={props.authStore}
+// 					SearchBox={
+// 						<PlacesWithSearchBox
+// 							{...props}
+// 							{...googleProps}>
+// 							<TextInput
+// 								id="search"
+// 								name="search"
+// 								placeholder="buscar una dirección"
+// 							/>
+// 						</PlacesWithSearchBox>
+// 					}
+// 				/>
+// 			</div>
+// 		</div>
+// 	);
+// });
 
 class AddressBook extends Component {
 	static propTypes = {
@@ -219,14 +243,14 @@ class AddressBook extends Component {
 	//
 	handleAddAddress = async (value) => {
 		const input = { ...value };
-		const { onAddressAdded, googleProps } = this.props;
-		console.log(googleProps.locationRef);
-		if (googleProps.locationRef.latitude) {
-			Object.assign(input, {
-				geolocation: googleProps.locationRef,
-				metaddress: { ...googleProps.metadataMarker }
-			});
-		}
+		const { onAddressAdded } = this.props;
+		// console.log(googleProps.locationRef);
+		// if (googleProps.locationRef.latitude) {
+		// 	Object.assign(input, {
+		// 		geolocation: googleProps.locationRef,
+		// 		metaddress: { ...googleProps.metadataMarker }
+		// 	});
+		// }
 
 		await onAddressAdded(input);
 		if (this._accordionFormList) {
@@ -296,7 +320,7 @@ class AddressBook extends Component {
 		return (
 			<AccordionFormList
 				addNewItemButtonText={addNewItemButtonText}
-				components={{ ItemAddForm: CustomAddAddressForm, ItemEditForm: CustomEditAddressForm }}
+				components={{ ItemAddForm: CustomAddAddressForm, ItemEditForm: CustomAddAddressForm }}
 				deleteItemButtonText={deleteItemButtonText}
 				entryFormSubmitButtonText={entryFormSubmitButtonText}
 				itemAddFormProps={itemAddFormProps}

--- a/components/AddressBook/AddressBook.js
+++ b/components/AddressBook/AddressBook.js
@@ -1,220 +1,240 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import isEmpty from "lodash.isempty";
-import { withComponents } from "@reactioncommerce/components-context";
 import { addressToString, CustomPropTypes } from "@reactioncommerce/components/utils";
+import withGoogleMaps from "containers/maps/withGoogleMap";
 
 const NORMAL = "normal";
 const REVIEW = "review";
 
 class AddressBook extends Component {
-  static propTypes = {
-  	/**
-     * User account data.
-     */
-  	account: PropTypes.shape({
-  		/**
-       * Users saved addresses
-       */
-  		addressBook: CustomPropTypes.addressBook
-  	}),
-  	/**
-     * The text for the "Add a new address" text, if it is shown.
-     */
-  	addNewItemButtonText: PropTypes.string,
-  	/**
-     * You can provide a `className` prop that will be applied to the outermost DOM element
-     * rendered by this component. We do not recommend using this for styling purposes, but
-     * it can be useful as a selector in some situations.
-     */
-  	className: PropTypes.string,
-  	/**
-     * If you've set up a components context using @reactioncommerce/components-context
-     * (recommended), then this prop will come from there automatically. If you have not
-     * set up a components context or you want to override one of the components in a
-     * single spot, you can pass in the components prop directly.
-     */
-  	components: PropTypes.shape({
-  		/**
-       * Pass either the Reaction AccordionFormList component or your own component that
-       * accepts compatible props.
-       */
-  		AccordionFormList: CustomPropTypes.component.isRequired,
-  		/**
-       * Pass either the Reaction AddressForm component or your own component that
-       * accepts compatible props.
-       */
-  		AddressForm: CustomPropTypes.component.isRequired,
-  		/**
-       * Pass either the Reaction AddressReview component or your own component that
-       * accepts compatible props.
-       */
-  		AddressReview: CustomPropTypes.component.isRequired
-  	}).isRequired,
-  	/**
-     * The text for the "Delete address" text, if it is shown.
-     */
-  	deleteItemButtonText: PropTypes.string,
-  	/**
-     * The text for the "Save Changes" text, if it is shown.
-     */
-  	entryFormSubmitButtonText: PropTypes.string,
-  	/**
-     * Is data being saved
-     */
-  	isSaving: PropTypes.bool,
-  	/**
-     * Handles new address added to address book
-     */
-  	onAddressAdded: PropTypes.func,
-  	/**
-     * Handles address deletion from address book
-     */
-  	onAddressDeleted: PropTypes.func,
-  	/**
-     * Handles editing address in address book
-     */
-  	onAddressEdited: PropTypes.func,
-  	/**
-     * Validated entered value for the AddressReview
-     */
-  	validatedValue: PropTypes.object,
-  	/**
-     * Value for the AddressFrom
-     */
-  	value: PropTypes.object
-  };
+	static propTypes = {
+		/**
+	 * User account data.
+	 */
+		account: PropTypes.shape({
+			/**
+	   * Users saved addresses
+	   */
+			addressBook: CustomPropTypes.addressBook
+		}),
+		/**
+	 * The text for the "Add a new address" text, if it is shown.
+	 */
+		addNewItemButtonText: PropTypes.string,
+		/**
+	 * You can provide a `className` prop that will be applied to the outermost DOM element
+	 * rendered by this component. We do not recommend using this for styling purposes, but
+	 * it can be useful as a selector in some situations.
+	 */
+		className: PropTypes.string,
+		/**
+	 * If you've set up a components context using @reactioncommerce/components-context
+	 * (recommended), then this prop will come from there automatically. If you have not
+	 * set up a components context or you want to override one of the components in a
+	 * single spot, you can pass in the components prop directly.
+	 */
+		components: PropTypes.shape({
+			/**
+	   * Pass either the Reaction AccordionFormList component or your own component that
+	   * accepts compatible props.
+	   */
+			AccordionFormList: CustomPropTypes.component.isRequired,
+			/**
+	   * Pass either the Reaction AddressForm component or your own component that
+	   * accepts compatible props.
+	   */
+			AddressForm: CustomPropTypes.component.isRequired,
+			/**
+	   * Pass either the Reaction AddressReview component or your own component that
+	   * accepts compatible props.
+	   */
+			AddressReview: CustomPropTypes.component.isRequired
+		}).isRequired,
+		/**
+	 * The text for the "Delete address" text, if it is shown.
+	 */
+		deleteItemButtonText: PropTypes.string,
+		/**
+	 * The text for the "Save Changes" text, if it is shown.
+	 */
+		entryFormSubmitButtonText: PropTypes.string,
+		/**
+	 * Is data being saved
+	 */
+		isSaving: PropTypes.bool,
+		/**
+	 * Handles new address added to address book
+	 */
+		onAddressAdded: PropTypes.func,
+		/**
+	 * Handles address deletion from address book
+	 */
+		onAddressDeleted: PropTypes.func,
+		/**
+	 * Handles editing address in address book
+	 */
+		onAddressEdited: PropTypes.func,
+		/**
+	 * Validated entered value for the AddressReview
+	 */
+		validatedValue: PropTypes.object,
+		/**
+	 * Value for the AddressFrom
+	 */
+		value: PropTypes.object
+	};
 
-  static defaultProps = {
-  	account: {
-  		addressBook: []
-  	},
-  	addNewItemButtonText: "Agregar nueva dirección",
-  	deleteItemButtonText: "Eliminar dirección",
-  	entryFormSubmitButtonText: "Guardar cambios",
-  	isSaving: false,
-  	onAddressAdded(values) {
-  	},
-  	onAddressDeleted(values) {
-  	},
-  	onAddressEdited(values) {
-  	},
-  	validatedValue: {},
-  	value: {}
-  };
+	static defaultProps = {
+		account: {
+			addressBook: []
+		},
+		addNewItemButtonText: "Agregar nueva dirección",
+		deleteItemButtonText: "Eliminar dirección",
+		entryFormSubmitButtonText: "Guardar cambios",
+		isSaving: false,
+		onAddressAdded(values) {
+		},
+		onAddressDeleted(values) {
+		},
+		onAddressEdited(values) {
+		},
+		validatedValue: {},
+		value: {}
+	};
 
-  state = {
-  	status: this.currentStatus
-  };
+	state = {
+		status: this.currentStatus
+	};
 
-  _addressReview = null;
-  _accordionFormList = null;
+	_addressReview = null;
+	_accordionFormList = null;
 
-  //
-  // Helper Methods
-  //
-  get currentStatus() {
-  	// eslint-disable-next-line
-    return isEmpty(this.props.validatedValue) ? NORMAL : REVIEW;
-  }
+	//
+	// Helper Methods
+	//
+	get currentStatus() {
+		// eslint-disable-next-line
+		return isEmpty(this.props.validatedValue) ? NORMAL : REVIEW;
+	}
 
-  get hasAddress() {
-  	const { account: { addressBook } } = this.props;
-  	return !isEmpty(addressBook);
-  }
+	get hasAddress() {
+		const { account: { addressBook } } = this.props;
+		return !isEmpty(addressBook);
+	}
 
-  //
-  // Handler Methods
-  //
-  handleAddAddress = async (value) => {
-  	const { onAddressAdded } = this.props;
-  	await onAddressAdded(value);
-  	if (this._accordionFormList) {
-  		this._accordionFormList.showList();
-  	}
-  };
+	//
+	// Handler Methods
+	//
+	handleAddAddress = async (value) => {
+		const input = { ...value };
+		const { onAddressAdded, googleProps } = this.props;
+		console.log(googleProps.locationRef);
+		if (googleProps.locationRef.latitude) {
+			Object.assign(input, {
+				geolocation: googleProps.locationRef,
+				metaddress: { ...googleProps.metadataMarker }
+			});
+		}
 
-  handleDeleteAddress = async (id) => {
-  	const { onAddressDeleted } = this.props;
-  	await onAddressDeleted(id);
-  };
+		await onAddressAdded(input);
+		if (this._accordionFormList) {
+			this._accordionFormList.showList();
+		}
+	};
 
-  handleEditAddress = async (value, _id) => {
-  	const { onAddressEdited } = this.props;
-  	await onAddressEdited(_id, value);
-  	if (this._accordionFormList) {
-  		this._accordionFormList.toggleAccordionForItem(_id);
-  	}
-  };
+	handleDeleteAddress = async (id) => {
+		const { onAddressDeleted } = this.props;
+		await onAddressDeleted(id);
+	};
 
-  //
-  // Render Methods
-  //
-  renderAccordionFormList() {
-  	const {
-  		account: { addressBook },
-  		addNewItemButtonText,
-  		components: { AccordionFormList, AddressForm },
-  		deleteItemButtonText,
-  		entryFormSubmitButtonText,
-  		isSaving
-  	} = this.props;
+	handleEditAddress = async (value, _id) => {
+		const input = { ...value };
+		const { onAddressEdited, googleProps } = this.props;
+		console.log(googleProps.locationRef);
 
-  	const items = addressBook.map(({ _id, ...address }) => ({
-  		id: _id,
-  		detail: `${address.address}, ${address.reference}`,
-  		itemEditFormProps: {
-  			isOnDarkBackground: true,
-  			isSaving,
-  			onSubmit: (value) => {
-  				this.handleEditAddress(value, _id);
-  			},
-  			value: address
-  		},
-  		label: address.description
-  	}));
+		if (googleProps.locationRef.latitude) {
+			Object.assign(input, {
+				geolocation: googleProps.locationRef,
+				metaddress: { ...googleProps.metadataMarker }
+			});
+		}
+		await onAddressEdited(_id, input);
+		if (this._accordionFormList) {
+			this._accordionFormList.toggleAccordionForItem(_id);
+		}
+	};
 
-  	const itemAddFormProps = {
-  		isSaving,
-  		onSubmit: this.handleAddAddress
-  	};
+	//
+	// Render Methods
+	//
+	renderAccordionFormList() {
+		const {
+			account: { addressBook },
+			addNewItemButtonText,
+			components: { AccordionFormList, AddressForm },
+			deleteItemButtonText,
+			entryFormSubmitButtonText,
+			isSaving,
+			googleProps
+		} = this.props;
 
-  	return (
-  		<AccordionFormList
-  			addNewItemButtonText={addNewItemButtonText}
-  			components={{ ItemAddForm: AddressForm, ItemEditForm: AddressForm }}
-  			deleteItemButtonText={deleteItemButtonText}
-  			entryFormSubmitButtonText={entryFormSubmitButtonText}
-  			itemAddFormProps={itemAddFormProps}
-  			items={items}
-  			onItemDeleted={this.handleDeleteAddress}
-  			ref={(instance) => { this._accordionFormList = instance; }}
-  		/>
-  	);
-  }
+		const items = addressBook.map(({ _id, ...address }) => ({
+			id: _id,
+			detail: `${address.address}, ${address.reference}`,
+			itemEditFormProps: {
+				isOnDarkBackground: true,
+				isSaving,
+				onSubmit: (value) => {
+					this.handleEditAddress(value, _id);
+				},
+				value: address
+			},
+			label: address.description
+		}));
 
-  renderAddressReview() {
-  	const { components: { AddressReview }, value, validatedValue } = this.props;
-  	return (
-  		<AddressReview
-  			ref={(el) => {
-  				this._addressReview = el;
-  			}}
-  			addressEntered={value}
-  			addressSuggestion={validatedValue}
-  		/>
-  	);
-  }
+		const itemAddFormProps = {
+			isSaving,
+			onSubmit: this.handleAddAddress
+		};
 
-  render() {
-  	const { className } = this.props;
-  	const { status } = this.state;
-  	return (
-  		<div className={className}>
-  			{status === REVIEW ? this.renderAddressReview() : this.renderAccordionFormList()}
-  		</div>
-  	);
-  }
+		return (
+			<AccordionFormList
+				addNewItemButtonText={addNewItemButtonText}
+				components={{ ItemAddForm: AddressForm, ItemEditForm: AddressForm }}
+				deleteItemButtonText={deleteItemButtonText}
+				entryFormSubmitButtonText={entryFormSubmitButtonText}
+				itemAddFormProps={itemAddFormProps}
+				items={items}
+				googleProps={googleProps}
+				onItemDeleted={this.handleDeleteAddress}
+				ref={(instance) => { this._accordionFormList = instance; }}
+			/>
+		);
+	}
+
+	renderAddressReview() {
+		const { components: { AddressReview }, value, validatedValue } = this.props;
+		return (
+			<AddressReview
+				ref={(el) => {
+					this._addressReview = el;
+				}}
+				addressEntered={value}
+				addressSuggestion={validatedValue}
+			/>
+		);
+	}
+
+	render() {
+		const { className } = this.props;
+		const { status } = this.state;
+		return (
+			<div className={className}>
+				{status === REVIEW ? this.renderAddressReview() : this.renderAccordionFormList()}
+			</div>
+		);
+	}
 }
 
-export default withComponents(AddressBook);
+export default withGoogleMaps(AddressBook);

--- a/components/AddressBook/AddressBook.js
+++ b/components/AddressBook/AddressBook.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, useImperativeHandle, useRef } from "react";
 import PropTypes from "prop-types";
 import isEmpty from "lodash.isempty";
 import { addressToString, CustomPropTypes } from "@reactioncommerce/components/utils";
@@ -40,18 +40,23 @@ const CustomAddAddressForm = withGoogleMaps((props) => {
 			});
 		}
 
+		console.log(input);
+
 		onSubmit(input);
 	};
 
 	let _formRef = null;
 
-	function submit() {
-		console.log("submit function executed");
-		_formRef.submit();
-	}
+	useImperativeHandle(props.formRef, () => ({
+		submit() {
+			_formRef.submit();
+		}
+	}));
 
 	return (
-		<div>
+		<div
+			ref={props.formRef}
+		>
 			<CustomForm
 				{...itemAddFormProps}
 				onSubmit={handleSubmit}
@@ -83,44 +88,6 @@ const CustomAddAddressForm = withGoogleMaps((props) => {
 		</div>
 	);
 });
-
-console.log(CustomAddAddressForm)
-
-// const CustomEditAddressForm = withGoogleMaps((props) => {
-// 	const { components: { CustomForm, TextInput }, googleProps, ...itemAddFormProps } = props;
-// 	let _formRef = null;
-
-// 	return (
-// 		<div>
-// 			<CustomForm
-// 				{...itemAddFormProps}
-// 				ref={(formEl) => {
-// 					_formRef = formEl;
-// 				}}
-// 			/>
-// 			<div style={{
-// 				width: "100%",
-// 				height: "300px"
-// 			}}>
-// 				<GoogleMapComponent
-// 					{...googleProps}
-// 					authStore={props.authStore}
-// 					SearchBox={
-// 						<PlacesWithSearchBox
-// 							{...props}
-// 							{...googleProps}>
-// 							<TextInput
-// 								id="search"
-// 								name="search"
-// 								placeholder="buscar una dirección"
-// 							/>
-// 						</PlacesWithSearchBox>
-// 					}
-// 				/>
-// 			</div>
-// 		</div>
-// 	);
-// });
 
 class AddressBook extends Component {
 	static propTypes = {
@@ -242,17 +209,8 @@ class AddressBook extends Component {
 	// Handler Methods
 	//
 	handleAddAddress = async (value) => {
-		const input = { ...value };
 		const { onAddressAdded } = this.props;
-		// console.log(googleProps.locationRef);
-		// if (googleProps.locationRef.latitude) {
-		// 	Object.assign(input, {
-		// 		geolocation: googleProps.locationRef,
-		// 		metaddress: { ...googleProps.metadataMarker }
-		// 	});
-		// }
-
-		await onAddressAdded(input);
+		await onAddressAdded(value);
 		if (this._accordionFormList) {
 			this._accordionFormList.showList();
 		}
@@ -264,17 +222,8 @@ class AddressBook extends Component {
 	};
 
 	handleEditAddress = async (value, _id) => {
-		const input = { ...value };
 		const { onAddressEdited } = this.props;
-		// console.log(googleProps.locationRef);
-
-		// if (googleProps.locationRef.latitude) {
-		// 	Object.assign(input, {
-		// 		geolocation: googleProps.locationRef,
-		// 		metaddress: { ...googleProps.metadataMarker }
-		// 	});
-		// }
-		await onAddressEdited(_id, input);
+		await onAddressEdited(_id, value);
 		if (this._accordionFormList) {
 			this._accordionFormList.toggleAccordionForItem(_id);
 		}
@@ -309,6 +258,7 @@ class AddressBook extends Component {
 			},
 			label: address.description
 		}));
+		console.log(items);
 
 		const itemAddFormProps = {
 			isSaving,

--- a/containers/maps/withGoogleMap.js
+++ b/containers/maps/withGoogleMap.js
@@ -71,8 +71,8 @@ export default function withGoogleMaps(Component){
 	const WithGoogleMap = React.forwardRef((props,ref)=>{
 		const GoogleMapLayout = enhance(googleProps=>
 			<Component
-				ref={ref}
 				{...props}
+				ref={ref}
 				googleProps={googleProps}
 			/>);
 		return <GoogleMapLayout/>;


### PR DESCRIPTION
Impact: **breaking**
Type: **feature**

## Issue
Users can create an address without adding geolocation from profile options, this allows to user buy items without pay shipping cost

## Solution
Add geolocation interface to make required geopoint when address is created from profile settings

![image](https://user-images.githubusercontent.com/69092583/139348599-5aaf2b62-e8fb-4493-9917-65b9eeb2c796.png)

